### PR TITLE
Fix show edit blade qr code display

### DIFF
--- a/resources/views/deployed_items/edit.blade.php
+++ b/resources/views/deployed_items/edit.blade.php
@@ -6,6 +6,9 @@
 <div class="intro-y flex flex-col sm:flex-row items-center mt-8">
     <h2 class="text-lg font-medium mr-auto">Edit Deployed Item</h2>
     <div class="w-full sm:w-auto flex mt-4 sm:mt-0">
+        <button type="button" class="btn btn-outline-primary shadow-md mr-2" onclick="showQRCode('{{ $deployedItem->qr_code ?? $deployedItem->qrCode }}')">
+            <i data-lucide="qrcode" class="w-4 h-4 mr-2"></i> Show QR Code
+        </button>
         <a href="{{ route('deployed-items.index') }}" class="btn btn-secondary shadow-md mr-2">
             <i data-lucide="arrow-left" class="w-4 h-4 mr-2"></i> Back to Deployed Items
         </a>
@@ -31,14 +34,14 @@
         <!-- Department -->
         <div class="col-span-12 md:col-span-6">
             <div class="input-form">
-                <label for="department_id" class="form-label">Department <span class="text-danger">*</span></label>
-                <select id="department_id" name="department_id" class="form-select w-full @error('department_id') border-danger @enderror" required>
+                <label for="departmentID" class="form-label">Department <span class="text-danger">*</span></label>
+                <select id="departmentID" name="departmentID" class="form-select w-full @error('departmentID') border-danger @enderror" required>
                     <option value="">Select Department</option>
                     @foreach($departments as $id => $name)
-                        <option value="{{ $id }}" {{ old('department_id', $deployedItem->department_id) == $id ? 'selected' : '' }}>{{ $name }}</option>
+                        <option value="{{ $id }}" {{ old('departmentID', $deployedItem->departmentID ?? $deployedItem->department_id) == $id ? 'selected' : '' }}>{{ $name }}</option>
                     @endforeach
                 </select>
-                @error('department_id')
+                @error('departmentID')
                     <div class="text-danger mt-2">{{ $message }}</div>
                 @enderror
             </div>
@@ -147,6 +150,26 @@
             </div>
         </div>
 
+        <!-- QR Code -->
+        <div class="col-span-12 md:col-span-6">
+            <div class="input-form">
+                <label for="qr_code" class="form-label">QR Code <span class="text-danger">*</span></label>
+                <div class="flex">
+                    <input type="text" id="qr_code" name="qr_code" 
+                           class="form-control w-full rounded-r-none @error('qr_code') border-danger @enderror" 
+                           value="{{ old('qr_code', $deployedItem->qr_code ?? $deployedItem->qrCode) }}"
+                           required readonly>
+                    <button type="button" onclick="generateQRCode()"
+                            class="btn btn-outline-secondary rounded-l-none border-l-0 px-4">
+                        <i data-lucide="refresh-cw" class="w-4 h-4"></i>
+                    </button>
+                </div>
+                @error('qr_code')
+                    <div class="text-danger mt-2">{{ $message }}</div>
+                @enderror
+            </div>
+        </div>
+
         <!-- Remarks -->
         <div class="col-span-12">
             <div class="input-form">
@@ -165,4 +188,80 @@
         </div>
     </form>
 </div>
+
+<!-- QR Code Modal -->
+<div class="modal" id="qr-modal">
+    <div class="modal__content">
+        <div class="p-5 text-center">
+            <div id="qrcode" class="mx-auto"></div>
+            <div class="mt-4">
+                <button type="button" class="btn btn-secondary mt-3" onclick="closeModal()">Close</button>
+                <button type="button" class="btn btn-primary mt-3" onclick="printQRCode()">
+                    <i data-lucide="printer" class="w-4 h-4 mr-2"></i> Print
+                </button>
+            </div>
+        </div>
+    </div>
+</div>
+
+@push('scripts')
+<script src="https://cdnjs.cloudflare.com/ajax/libs/qrcodejs/1.0.0/qrcode.min.js"></script>
+<script>
+    function showQRCode(qrData) {
+        document.getElementById('qrcode').innerHTML = '';
+        new QRCode(document.getElementById("qrcode"), {
+            text: qrData,
+            width: 200,
+            height: 200,
+            colorDark : "#000000",
+            colorLight : "#ffffff",
+            correctLevel : QRCode.CorrectLevel.H
+        });
+        document.getElementById('qr-modal').classList.add('show');
+    }
+    
+    function closeModal() {
+        document.getElementById('qr-modal').classList.remove('show');
+    }
+    
+    function printQRCode() {
+        const printWindow = window.open('', '_blank');
+        const qrCodeContent = document.getElementById('qrcode').innerHTML;
+        printWindow.document.write(`
+            <!DOCTYPE html>
+            <html>
+            <head>
+                <title>QR Code - {{ $deployedItem->itemName }}</title>
+                <style>
+                    body { text-align: center; padding: 20px; }
+                    .qrcode { margin: 0 auto; }
+                    .item-name { font-size: 18px; font-weight: bold; margin: 10px 0; }
+                    .item-code { font-family: monospace; margin: 10px 0; }
+                    @media print {
+                        @page { margin: 0; }
+                        body { padding: 15mm; }
+                    }
+                </style>
+            </head>
+            <body>
+                <div class="item-name">{{ $deployedItem->itemName }}</div>
+                <div class="item-code">{{ $deployedItem->qr_code ?? $deployedItem->qrCode }}</div>
+                <div class="qrcode">${qrCodeContent}</div>
+                <script>window.onload = () => window.print()<\/script>
+            </body>
+            </html>
+        `);
+        printWindow.document.close();
+    }
+    
+    function generateQRCode() {
+        // Generate a new QR code with timestamp and random string
+        const timestamp = Date.now();
+        const randomString = Math.random().toString(36).substring(2, 8).toUpperCase();
+        const newQRCode = `DEP-${timestamp}-${randomString}`;
+        document.getElementById('qr_code').value = newQRCode;
+    }
+</script>
+@endpush
+
 @endsection

--- a/resources/views/deployed_items/show.blade.php
+++ b/resources/views/deployed_items/show.blade.php
@@ -7,7 +7,7 @@
     <div class="intro-y flex flex-col sm:flex-row items-center mt-8">
         <h2 class="text-lg font-medium mr-auto">Deployed Item Details</h2>
         <div class="w-full sm:w-auto flex mt-4 sm:mt-0">
-            <button type="button" class="btn btn-secondary" onclick="showQRCode('{{ $deployedItem->qrCode }}')">
+            <button type="button" class="btn btn-secondary" onclick="showQRCode('{{ $deployedItem->qr_code ?? $deployedItem->qrCode }}')">
                 <i data-lucide="qrcode" class="w-4 h-4 mr-2"></i> Show QR Code
             </button>
             <a href="{{ route('deployed-items.index') }}" class="btn btn-outline-secondary ml-2">
@@ -63,7 +63,7 @@
                 
                 <div class="md:col-span-2">
                     <div class="text-slate-500">QR Code</div>
-                    <div class="font-mono text-xs bg-slate-100 dark:bg-darkmode-800 p-2 rounded inline-block">{{ $deployedItem->qrCode }}</div>
+                    <div class="font-mono text-xs bg-slate-100 dark:bg-darkmode-800 p-2 rounded inline-block">{{ $deployedItem->qr_code ?? $deployedItem->qrCode }}</div>
                 </div>
             </div>
         </div>
@@ -220,7 +220,7 @@
                     </head>
                     <body>
                         <div class="item-name">{{ $deployedItem->itemName }}</div>
-                        <div class="item-code">{{ $deployedItem->qrCode }}</div>
+                        <div class="item-code">{{ $deployedItem->qr_code ?? $deployedItem->qrCode }}</div>
                         <div class="qrcode">${qrCodeContent}</div>
                         <script>window.onload = () => window.print()<\/script>
                     </body>


### PR DESCRIPTION
Adds QR code functionality to the deployed items edit blade and fixes QR code display and department ID mapping in both show and edit blades.

The `show.blade.php` template was referencing an outdated `qrCode` column name instead of `qr_code`, causing the QR code to not display. The `edit.blade.php` template entirely lacked QR code display and generation features. Additionally, the `department_id` field in the edit form did not match the controller's `departmentID` validation rule. This PR addresses these issues, ensuring consistent and functional QR code management across both views.

---
<a href="https://cursor.com/background-agent?bcId=bc-84b5b521-cbdb-4a0d-bab8-6dc3f2c5c37e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-84b5b521-cbdb-4a0d-bab8-6dc3f2c5c37e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

